### PR TITLE
Corrects issues related to enhancement related to volunteers

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -6,5 +6,6 @@ class RegistrationsController < Devise::RegistrationsController
     params.require(:volunteer).permit(:name, :gender, :"date_of_birth(3i)", :"date_of_birth(2i)", :"date_of_birth(1i)",
       :mobile, :profession, :other_talents, :about_me, :email, :password, :password_confirmation,
       target_group_ids: [], availability_ids: [], skill_ids: [], center_ids: [], formal_education_ids: [])
+  end
 
 end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -10,6 +10,8 @@ class Volunteer < ApplicationRecord
   has_many :skills, through: :skills_volunteers
   has_many :preferred_centers
   has_many :centers, through: :preferred_centers
+  has_many :preferred_availabilities
+  has_many :availabilities, through: :preferred_availabilities
   has_one :highest_education
   has_one :formal_education, through: :highest_education
 

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -29,12 +29,27 @@ h2 Edit your details #{current_volunteer.name}
     = f.text_field :profession
 
   div
-    = f.label :'Preferred Taget Group'
+    = f.label :'Highest Education'
+    br
+    = f.collection_select :highest_education, FormalEducation.all, :id, :name, prompt: true
+
+  div
+    = f.label :'Preferred Center(s)'
+    br
+    = f.collection_check_boxes :center_ids, Center.all, :id, :name
+
+  div
+    = f.label :'Preferred Target Group(s)'
     br
     = f.collection_check_boxes :target_group_ids, TargetGroup.all, :id, :name
 
   div
-    = f.label :'Skills you can offer'
+    = f.label :'Preferred Availability(s)'
+    = f.collection_check_boxes :availability_ids, Availability.all, :id, :name
+
+
+  div
+    = f.label :'Skill(s) you can offer'
     br
     = f.collection_check_boxes :skill_ids, Skill.all, :id, :name
 

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -56,21 +56,21 @@ h2 Sign up
     = f.collection_select :highest_education, FormalEducation.all, :id, :name, prompt: true
 
   div
-    = f.label :'Preferred Centers'
+    = f.label :'Preferred Center(s)'
     br
     = f.collection_check_boxes :center_ids, Center.all, :id, :name
 
   div
-    = f.label :'Preferred Target Group'
+    = f.label :'Preferred Target Group(s)'
     br
     = f.collection_check_boxes :target_group_ids, TargetGroup.all, :id, :name
 
   div
-    = f.label :'Preferred Availability'
+    = f.label :'Preferred Availability(s)'
     = f.collection_check_boxes :availability_ids, Availability.all, :id, :name
 
   div
-    = f.label :'Skills you can offer'
+    = f.label :'Skill(s) you can offer'
     br
     = f.collection_check_boxes :skill_ids, Skill.all, :id, :name
 


### PR DESCRIPTION
This PR corrects some errors that have been interfering with the volunteer's signing up and editing of profile, thus preventing successful sign in by volunteers. The changes are as follows.
1. resolved the _undefined method_ error by adding the missing availabilities relations into the volunteer model (has_many :availabilities and has_many :preferred availabilities were missing)
2. added the missing ‘end’ into the registrations_controller to eliminate the syntax error 
3. corrected mispelt “target centers” (was spelt as taget center) inside the edit profile page
4. corrected a few grammatically incorrect labels in both the edit profile and sign up profile pages by adding (s) for labels that apply for possibly more than one item (ie. preferred center(s) instead of preferred center because a volunteer can have many preferred centers)
5. added missing sections into the edit profile page
