### PR TITLE
reorganise volunteer forms to be presentable on both desktop and mobi…

### DIFF
--- a/app/views/admin/volunteers/edit.html.slim
+++ b/app/views/admin/volunteers/edit.html.slim
@@ -1,20 +1,21 @@
-h2 Edit volunteer details
+.container
+  h2 Edit volunteer details
 
-= form_for [:admin, @volunteer] do |f| 
+  = form_for [:admin, @volunteer] do |f| 
 
-  = render partial: 'devise/registrations/form', locals: { f: f }
+    = render partial: 'devise/registrations/form', locals: { f: f }
 
-  div
-    = f.label 'Would you like to volunteer on a regular bases?'
-    br
-    = f.label 'Yes'
-    = f.radio_button :adhoc, '0'
+    div
+      = f.label 'Would you like to volunteer on a regular bases?'
+      br
+      = f.label 'Yes'
+      = f.radio_button :adhoc, '0'
 
-    = f.label 'No'
-    = f.radio_button :adhoc, '1'
+      = f.label 'No'
+      = f.radio_button :adhoc, '1'
 
-  .actions
-    = f.submit
-  
-div
-  = link_to 'Back', :back 
+  .form-inline
+    .form-group
+      .actions
+        .button
+          input.btn.btn-primary type="submit" value=("Update Volunteer Details")

--- a/app/views/admin/volunteers/index.html.slim
+++ b/app/views/admin/volunteers/index.html.slim
@@ -41,4 +41,4 @@
           td = t(:"admin.volunteers.index.value_#{volunteer.email_notification}")
           td = t(:"admin.volunteers.index.value_#{volunteer.adhoc}")
           td = volunteer.deleted_at
-          td = link_to 'Edit', edit_admin_volunteer_path(volunteer), class: 'btn btn-primary'
+          td = link_to 'Edit', edit_admin_volunteer_path(volunteer), class: 'btn btn-default'

--- a/app/views/devise/registrations/_form.html.slim
+++ b/app/views/devise/registrations/_form.html.slim
@@ -1,43 +1,9 @@
 .row
-  .col-xs-12
+  .col-xs-12.col-sm-9
     .form-group
       = f.label :name
       = f.text_field :name, autofocus: true, class: "form-control", placeholder: "full name as per NRIC/FIN"
-
-.row
-  .col-xs-8
-    .form-group
-      = f.label :email
-      = f.email_field :email, class: "form-control", placeholder: "a valid email is required for account confirmation."
-  .col-xs-4
-    .form-group
-      = f.label :mobile
-      = f.telephone_field :mobile, class: "form-control", placeholder: "include country code"
-
-- unless current_volunteer || current_admin
-  .row
-    .col-xs-4
-      .form-group
-        = f.label :password
-        - if @minimum_password_length
-          = f.password_field :password, autocomplete: "off", class: "form-control", placeholder: "(minimum #{@minimum_password_length} characters)"
-    .col-xs-4
-      .form-group
-        = f.label :confirm_password
-        = f.password_field :password_confirmation, autocomplete: "off", class: "form-control", placeholder: "please re-enter"
-
-.row
-  .col-xs-4
-    .form-group
-      = f.label :profession
-      = f.text_field :profession, class: "form-control", placeholder: "what do you work as?"
-  .col-xs-4
-    .form-group
-      = f.label :highest_education
-      = f.collection_select :formal_education_id, FormalEducation.all, :id, :name, { prompt: true }, class: "form-control"
-
-.row
-  .col-xs-12
+  .col-xs-12.col-sm-3
     .form-group
       = f.label :gender
       br
@@ -47,14 +13,41 @@
       label.radio-inline
         input#male name="gender" type="radio" value="false"
         | Male
-
+- unless current_volunteer || current_admin
+  .row
+    .col-xs-12.col-sm-6
+      .form-group
+        = f.label :password
+        - if @minimum_password_length
+          = f.password_field :password, autocomplete: "off", class: "form-control", placeholder: "(minimum #{@minimum_password_length} characters)"
+    .col-xs-12.col-sm-6
+      .form-group
+        = f.label :confirm_password
+        = f.password_field :password_confirmation, autocomplete: "off", class: "form-control", placeholder: "please re-enter"
 .row
-  .col-xs-12
+  .col-xs-12.col-sm-4
+    .form-group
+      = f.label :mobile
+      = f.telephone_field :mobile, class: "form-control", placeholder: "include country code"
+  .col-xs-12.col-sm-5
+    .form-group
+      = f.label :email
+      = f.email_field :email, class: "form-control", placeholder: "a valid email is required for account confirmation."
+.row
+  .col-xs-12.col-sm-4
+    .form-group
+      = f.label :profession
+      = f.text_field :profession, class: "form-control", placeholder: "what do you work as?"
+  .col-xs-12.col-sm-4
+    .form-group
+      = f.label :highest_education
+      = f.collection_select :formal_education_id, FormalEducation.all, :id, :name, { prompt: true }, class: "form-control"
+  .col-xs-12.col-sm-4
     .form-inline
       .form-group
         = f.label :date_of_birth
+        br
         = f.date_select :date_of_birth, {order: [:day, :month, :year], :start_year => Date.today.year - 80, :end_year => Date.today.year - 5}, class: "form-control"
-
 .row
   .col-xs-12
     .form-group
@@ -101,21 +94,17 @@
           = b.label
 
 .row
-  .col-xs-12
+  .col-xs-12.col-sm-6
     .form-group
-      .col-xs-8
-        =f.label :other_talents
-        = f.text_area :other_talents, class: "form-control", placeholder: "please elaborate on your other talent if you have checked the last box (Other)"
+      =f.label :other_talents
+      = f.text_area :other_talents, class: "form-control", placeholder: "please elaborate on your other talent if you have checked the last box (Other)"
+  .col-xs-12.col-sm-6
+    .form-group
+      =f.label :about_me
+      = f.text_area :about_me, class: "form-control", placeholder: "tell us more about yourself! :)"
 
 .row
-  .col-xs-12
-    .form-group
-      .col-xs-8
-        =f.label :about_me
-        = f.text_area :about_me, class: "form-control", placeholder: "tell us more about yourself! :)"
-
-.row
-  .col-xs-12
+  .col-xs-12.col-sm-12
     .form-group
       = f.label 'Would you like to recieve email notifications?'
       br


### PR DESCRIPTION
This PR reorganises volunteer forms to be presentable on both desktop and mobile devices, as well as standardised to the styles of other forms.

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains models, ensure that:

 - [ ] You have included an updated screenshot of the ERD.
 - [ ] You have added database seeds for the model.
 - [ ] You have added working factories for the model.
 - [ ] Your validations have corresponding database constraints.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.
![image](https://cloud.githubusercontent.com/assets/21137081/20432266/436607d0-add9-11e6-91e1-0cc5423ec470.png)

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


…le devise sizes