### PR TITLE
add route and tab for approved volunteers

### DIFF
--- a/app/controllers/admin/volunteer_events_controller.rb
+++ b/app/controllers/admin/volunteer_events_controller.rb
@@ -31,6 +31,17 @@ class Admin::VolunteerEventsController < Admin::BaseController
     @volunteer_event.decline!
   end
 
+  def approved
+    @event = find_event
+    @approved_volunteer_events = @event.volunteer_events.approved
+  end
+
+  def attended
+    @event = find_event
+    @volunteer_event = find_volunteer_event
+    @volunteer_event.attended!
+  end
+
   private
 
   def find_event

--- a/app/views/admin/events/show.html.slim
+++ b/app/views/admin/events/show.html.slim
@@ -29,7 +29,7 @@
         li#volunteer-tab-pending
           = link_to 'Pending Volunteers', pending_admin_event_volunteer_events_path(@event), remote: true
         li#volunteer-tab-approved
-          = link_to 'Approved Volunteers', admin_volunteer_path
+          = link_to 'Approved Volunteers', approved_admin_event_volunteer_events_path(@event), remote: true
 
       #tab-content
 

--- a/app/views/admin/volunteer_events/_volunteers.html.slim
+++ b/app/views/admin/volunteer_events/_volunteers.html.slim
@@ -22,3 +22,4 @@
               td
                 = link_to 'Approve', approve_admin_event_volunteer_event_path(volunteer_event.event, volunteer_event), class: 'btn btn-primary', method: :patch, remote: true
                 = link_to 'Decline', decline_admin_event_volunteer_event_path(volunteer_event.event, volunteer_event), class: 'btn btn-danger btn-sm', data: { confirm: 'Are you sure?' }, method: :patch, remote: true
+               

--- a/app/views/admin/volunteer_events/approved.js.erb
+++ b/app/views/admin/volunteer_events/approved.js.erb
@@ -1,0 +1,7 @@
+$("#volunteer-tabs li").removeClass("active");
+$("#volunteer-tab-approved").addClass("active");
+
+var content = "<%= j render 'admin/volunteer_events/volunteers', title: 'Attendence', volunteer_events: @approved_volunteer_events %>";
+
+$("#tab-content").html(content);
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,12 +11,14 @@ Rails.application.routes.draw do
       patch 'cancel', on: :member
 
       resources :volunteer_events, only: [] do
+        get :approved, on: :collection
         get :pending, on: :collection
         get :find, on: :collection
 
         patch 'invite', on: :member
         patch 'approve', on: :member
         patch 'decline', on: :member
+        patch 'attended', on: :member
       end
     end
 


### PR DESCRIPTION
-added GET route for approved volunteers and PATCH route for attended
-defined approved and attended method in volunteer_events controllers
-created js for approved volunteer 

Problem: Under approved volunteers tag, it shows approve and decline button as pending volunteers tag. 

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [ ] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [ ] You have ensured that RuboCop is passing.
 - [ ] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains models, ensure that:

 - [ ] You have included an updated screenshot of the ERD.
 - [ ] You have added database seeds for the model.
 - [ ] You have added working factories for the model.
 - [ ] Your validations have corresponding database constraints.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.
<img width="899" alt="screen shot 2017-01-12 at 12 16 48 am" src="https://cloud.githubusercontent.com/assets/20937965/21856308/8785cb78-d85c-11e6-8ab9-979412d8e0b4.png">

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
