### PR TITLE
bugfix - admin edit event time/date

### DIFF
--- a/app/assets/javascripts/admin/events/common.js.coffee
+++ b/app/assets/javascripts/admin/events/common.js.coffee
@@ -2,13 +2,16 @@ class PPIS.Views.Admin_Events.Common
   render: ->
     $('.datetimepicker').datetimepicker
       format: 'Do MMMM YYYY'
-      extraFormats: [ 'DD.MM.YYYY', 'DD.MM.YY' ]
+      extraFormats: [ 'DD.MM.YYYY', 'DD.MM.YY', 'YYYY-MM-DD' ]
       calendarWeeks: true
       showClose: true
       allowInputToggle: true
+      useCurrent: true
 
     $('.datetimepicker3').datetimepicker
       format: 'HH:mm'
+      extraFormats: [ 'YYYY-MM-DD HH:mm:ss' ]
       stepping: 15
       showClose: true
       allowInputToggle: true
+      useCurrent: true


### PR DESCRIPTION
modify javascript to permit retention of previously saved date/time in the admins event edit page

![image](https://cloud.githubusercontent.com/assets/21137081/21887309/688f3be8-d8fa-11e6-8d8b-48eb607f7981.png)
before this pr:
![image](https://cloud.githubusercontent.com/assets/21137081/21887380/a3b1e806-d8fa-11e6-9296-b24b8ad54896.png)

after this pr:
![image](https://cloud.githubusercontent.com/assets/21137081/21887336/7e5591b6-d8fa-11e6-95e5-f61e49e9a4c7.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains models, ensure that:

 - [ ] You have included an updated screenshot of the ERD.
 - [ ] You have added database seeds for the model.
 - [ ] You have added working factories for the model.
 - [ ] Your validations have corresponding database constraints.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

