### PR TITLE
add design to forgot password and resend confirmation instruction pages

### DIFF
--- a/app/assets/stylesheets/controllers/devise/sessions/new.scss
+++ b/app/assets/stylesheets/controllers/devise/sessions/new.scss
@@ -1,4 +1,4 @@
-.devise-sessions-new {
+.devise-sessions-new, .devise-passwords-new, .devise-confirmations-new {
   background: #fff;
 
   input[type=checkbox]{

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,0 +1,23 @@
+.login-container
+  .login-header
+    h1.text-center Resend confirmation instructions
+
+  = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+
+    .form-horizonal
+      .form-group.row
+        .col-sm-8.col-sm-offset-2
+          .sr-only = f.label :email
+          .input-group
+            .input-group-addon
+              = fa_icon 'user'
+            = f.email_field :email, class: "form-control", placeholder: "Email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
+
+      div
+        .actions
+          .button.text-center
+            input.btn.btn-success type="submit" value=("Resend confirmation instructions")
+
+
+      .text-center
+        = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,0 +1,23 @@
+.login-container
+  .login-header
+    h1.text-center Forgot your password?
+
+  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+
+    .form-horizonal
+      .form-group.row
+        .col-sm-8.col-sm-offset-2
+          .sr-only = f.label :email
+          .input-group
+            .input-group-addon
+              = fa_icon 'user'
+            = f.email_field :email, class: "form-control", placeholder: "Email"
+
+      div
+        .actions
+          .button.text-center
+            input.btn.btn-success type="submit" value=("Send me reset password instructions")
+
+
+      .text-center
+        = render "devise/shared/links"


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/429011/25059512/898465fe-21ba-11e7-8e20-d39a074de9d1.png)

![image](https://cloud.githubusercontent.com/assets/429011/25059515/8f609718-21ba-11e7-9191-7cddd411e187.png)
